### PR TITLE
changing namespace for timedAttempt to avoid conflicts with time()

### DIFF
--- a/extras/test/src/time/test_TimedAttempt.cpp
+++ b/extras/test/src/time/test_TimedAttempt.cpp
@@ -14,7 +14,7 @@
 #include <Arduino.h>
 #include <limits.h>
 
-using namespace arduino::time;
+using namespace arduino::tattempt;
 
 SCENARIO("Test broker connection retries") {
   TimedAttempt _connection_attempt(0,0);

--- a/src/Arduino_TimedAttempt.h
+++ b/src/Arduino_TimedAttempt.h
@@ -11,4 +11,4 @@
 
 #include "./time/TimedAttempt.h"
 
-using namespace arduino::time;
+using namespace arduino::tattempt;

--- a/src/time/TimedAttempt.cpp
+++ b/src/time/TimedAttempt.cpp
@@ -12,7 +12,7 @@
 #include <Arduino.h>
 #include "TimedAttempt.h"
 
-namespace arduino { namespace time {
+namespace arduino { namespace tattempt {
 
     TimedAttempt::TimedAttempt(unsigned long minDelay, unsigned long maxDelay)
     : _minDelay(minDelay)
@@ -75,4 +75,4 @@ namespace arduino { namespace time {
         return _retryDelay;
     }
 
-}}  // arduino::time
+}}  // arduino::tattempt

--- a/src/time/TimedAttempt.h
+++ b/src/time/TimedAttempt.h
@@ -10,7 +10,7 @@
 
 #pragma once
 
-namespace arduino { namespace time {
+namespace arduino { namespace tattempt {
 
     /**
      * The TimedAttempt class manages retry attempts with configurable delays.
@@ -97,4 +97,4 @@ namespace arduino { namespace time {
         unsigned int _retryCount;
     };
 
-}}  // arduino::time
+}}  // arduino::tattempt


### PR DESCRIPTION
This PR aims to solve the issue appearing on IoTCloud which states `error: reference to 'time' is ambiguous` https://github.com/arduino-libraries/ArduinoIoTCloud/actions/runs/13768398142/job/38502459222?pr=527 